### PR TITLE
Range and number of valid element IDs

### DIFF
--- a/ebml.xml
+++ b/ebml.xml
@@ -33,7 +33,7 @@
 		<documentation lang="en" purpose="definition">The version of the DocTypeExtension. Different DocTypeExtensionVersion values of the same DocType + DocTypeVersion + DocTypeExtensionName tuple **MAY** contain completely different sets of extra Elements. An EBML Reader **MAY** support multiple versions	of the same tuple, only one version of the tuple, or not support the tuple at all.</documentation>
 	</element>
 
-	<element name="Void" path="\(-\)Void" id="0xEC" type="binary" maxOccurs="1">
+	<element name="Void" path="\(-\)Void" id="0xEC" type="binary">
 		<documentation lang="en" purpose="definition">Used to void damaged data, to avoid unexpected behaviors when using damaged data. The content is discarded. Also used to reserve space in a sub-element for later use.</documentation>
 	</element>
 	<element name="CRC-32" path="\(1-\)CRC-32" id="0xBF" type="binary" length="4" maxOccurs="1">

--- a/specification.markdown
+++ b/specification.markdown
@@ -275,7 +275,7 @@ octet length. Examples of this are provided in
 
 Element ID Octet Length | Range of Valid Element IDs   | Number of Valid Element IDs
 :----------------------:|:----------------------------:|-------------:
-1                       |       0x81 - 0xFE            |           126
+1                       |       0x80 - 0xFE            |           127
 2                       |     0x407F - 0x7FFE          |        16,256
 3                       |   0x203FFF - 0x3FFFFE        |     2,080,768
 4                       | 0x101FFFFF - 0x1FFFFFFE      |   268,338,304


### PR DESCRIPTION
After merging #408 the range and number of valid element IDs with 1 octet no longer correct.