### PR TITLE
EBML Schema path: add grouping to EBMLAtomName

### DIFF
--- a/rfc-editor/rfc8794.xml
+++ b/rfc-editor/rfc8794.xml
@@ -949,7 +949,7 @@ EBMLElement            = [IsRecursive] EBMLAtomName
 
 PathDelimiter          = &quot;\&quot;
 IsRecursive            = &quot;+&quot;
-EBMLAtomName           = ALPHA / DIGIT 0*EBMLNameChar
+EBMLAtomName           = (ALPHA / DIGIT) 0*EBMLNameChar
 EBMLNameChar           = ALPHA / DIGIT / &quot;-&quot; / &quot;.&quot;
 
 GlobalPlaceholder      = &quot;(&quot; GlobalParentOccurrence &quot;\)&quot;

--- a/specification.markdown
+++ b/specification.markdown
@@ -674,7 +674,7 @@ EBMLElement            = [IsRecursive] EBMLAtomName
 
 PathDelimiter          = "\"
 IsRecursive            = "+"
-EBMLAtomName           = ALPHA / DIGIT 0*EBMLNameChar
+EBMLAtomName           = (ALPHA / DIGIT) 0*EBMLNameChar
 EBMLNameChar           = ALPHA / DIGIT / "-" / "."
 
 GlobalPlaceholder      = "(" GlobalParentOccurrence "\)"


### PR DESCRIPTION
The `EBMLAtomName` ABNF rule was incorrectly specified: It failed to account for the higher operator precedence of concatenation vs. alternative, as stated in RFC 5234 section 3.10: https://datatracker.ietf.org/doc/html/rfc5234#section-3.10